### PR TITLE
Fix rename dialog dispatch bug

### DIFF
--- a/src/lib/layouts/rest/context-menus/context-menu-edit-request/context-menu-edit-request.layout.svelte
+++ b/src/lib/layouts/rest/context-menus/context-menu-edit-request/context-menu-edit-request.layout.svelte
@@ -82,13 +82,13 @@
 </script>
 
 <ContextMenu.Root bind:open>
-	<ContextMenu.Trigger on:contextmenu={() => restStore.setPredictedRequest(requestID)}>
+	<ContextMenu.Trigger>
 		<slot />
 	</ContextMenu.Trigger>
 	<ContextMenu.Content class="w-64">
 		{#each options as option}
 			{#if !option.showOnlyIf || option.showOnlyIf()}
-				<ContextMenu.Item on:click={option.action}>
+				<ContextMenu.Item inset on:click={option.action}>
 					{#if option.icon}
 						<svelte:component this={option.icon} class="w-4 h-4 mr-2" />
 					{/if}

--- a/src/lib/layouts/rest/dialogs/dialog-edit-request/dialog-edit-request.layout.svelte
+++ b/src/lib/layouts/rest/dialogs/dialog-edit-request/dialog-edit-request.layout.svelte
@@ -41,12 +41,8 @@
 	});
 
 	$: ({ form: formValue } = superFrm);
-	$: formRef = document.forms.namedItem(formID) as HTMLFormElement;
-	$: isActive = $restStore.activeRequest === requestID;
-	$: isPredicted = $restStore.predictedRequest === requestID;
-	$: showContent = $restStore.predictedRequest ? isPredicted : isActive;
 	$: open = $restStore.editRequest === requestID;
-	$: if ($restStore.requests) {
+	$: if ($restStore.activeRequest) {
 		const updatedRequest = restStore.getRequest(requestID);
 		if (updatedRequest) $formValue = updatedRequest;
 	}
@@ -58,13 +54,11 @@
 	function handleCancel() {
 		superFrm.reset();
 		restStore.setEditRequest(undefined);
-		restStore.setPredictedRequest(undefined);
 	}
 
 	function handleSave() {
 		restStore.updateRequest(requestID, $formValue);
 		restStore.setEditRequest(undefined);
-		restStore.setPredictedRequest(undefined);
 	}
 
 	function handleKeydownSubmit(event: KeyboardEvent) {
@@ -80,32 +74,30 @@
 	}
 </script>
 
-<Dialog.Root {open} closeOnOutsideClick={false}>
+<Dialog.Root bind:open closeOnOutsideClick={false}>
 	<Dialog.Trigger asChild>
 		<div role="presentation" tabindex="-1" on:dblclick={onDblClick}>
 			<slot />
 		</div>
 	</Dialog.Trigger>
 
-	{#if showContent}
-		<Dialog.Content>
-			<Dialog.Header>
-				<Dialog.Title>Edit Request</Dialog.Title>
-			</Dialog.Header>
+	<Dialog.Content transitionConfig={{ delay: 1000 }}>
+		<Dialog.Header>
+			<Dialog.Title>Edit Request</Dialog.Title>
+		</Dialog.Header>
 
-			<Form.Root id={formID} form={superFrm} {schema} controlled action="?/save" let:config>
-				<Form.Field {config} name="name">
-					<Form.Item>
-						<Form.Label for="name">Name</Form.Label>
-						<Form.Input type="text" id="name" name="name" on:keydown={handleKeydownSubmit} />
-					</Form.Item>
-				</Form.Field>
-			</Form.Root>
+		<Form.Root id={formID} form={superFrm} {schema} controlled action="?/save" let:config>
+			<Form.Field {config} name="name">
+				<Form.Item>
+					<Form.Label for="name">Name</Form.Label>
+					<Form.Input type="text" id="name" name="name" on:keydown={handleKeydownSubmit} />
+				</Form.Item>
+			</Form.Field>
+		</Form.Root>
 
-			<Dialog.Footer>
-				<Button type="submit" variant="ghost" form={formID} formaction="?/cancel">Cancel</Button>
-				<Button type="submit" variant="default" form={formID}>Save</Button>
-			</Dialog.Footer>
-		</Dialog.Content>
-	{/if}
+		<Dialog.Footer>
+			<Button type="submit" variant="ghost" form={formID} formaction="?/cancel">Cancel</Button>
+			<Button type="submit" variant="default" form={formID}>Save</Button>
+		</Dialog.Footer>
+	</Dialog.Content>
 </Dialog.Root>

--- a/src/lib/layouts/rest/views/view-rest/view-rest.layout.svelte
+++ b/src/lib/layouts/rest/views/view-rest/view-rest.layout.svelte
@@ -16,6 +16,10 @@
 	$: ({ requests } = $restStore);
 	$: hasOnlyOneRequest = requests.length === 1;
 
+	function handleActiveTab(id: TRESTRequestSchemaInfer['id']) {
+		restStore.setActiveRequest(id);
+	}
+
 	function handleCloseTab(
 		event: MouseEvent | KeyboardEvent,
 		requestID: TRESTRequestSchemaInfer['id']
@@ -38,7 +42,7 @@
 					class="relative justify-between gap-2 h-12 before:absolute before:top-0 before:inset-x-0 before:h-[.125rem] data-[state=active]:before:bg-primary before:bg-transparent"
 					aria-label={request.name}
 					value={request.id}
-					on:click={() => restStore.setActiveRequest(request.id)}
+					on:click={() => handleActiveTab(request.id)}
 				>
 					<DialogEditRequest {requestID} {form}>
 						<div class="tab-trigger-content">

--- a/src/lib/stores/rest.store.ts
+++ b/src/lib/stores/rest.store.ts
@@ -8,14 +8,12 @@ type TRESTData = {
 	requests: Array<TRESTRequestSchemaInfer>;
 	activeRequest: TRESTRequestSchemaInfer['id'];
 	editRequest?: TRESTRequestSchemaInfer['id'];
-	predictedRequest?: TRESTRequestSchemaInfer['id'];
 };
 type TRESTActions = {
 	addRequest: () => void;
 	getRequest: (id: TRESTRequestSchemaInfer['id']) => TRESTRequestSchemaInfer | undefined;
 	setActiveRequest: (id: TRESTRequestSchemaInfer['id']) => void;
 	setEditRequest: (id: TRESTRequestSchemaInfer['id'] | undefined) => void;
-	setPredictedRequest: (id: TRESTRequestSchemaInfer['id'] | undefined) => void;
 	closeRequest: (id: TRESTRequestSchemaInfer['id']) => void;
 	closeOtherRequests: (id: TRESTRequestSchemaInfer['id']) => void;
 	duplicateRequest: (id: TRESTRequestSchemaInfer['id']) => void;
@@ -103,20 +101,6 @@ export const setRESTStore = (initialData: Partial<TRESTData> = REST_INITIAL_DATA
 				return state;
 			});
 		},
-		setPredictedRequest: (id) => {
-			restStore.update((state) => {
-				if (!id) {
-					state.predictedRequest = undefined;
-					return state;
-				}
-
-				const index = state.requests.findIndex((request) => request.id === id);
-				if (index === -1) return state;
-
-				state.predictedRequest = id;
-				return state;
-			});
-		},
 		closeRequest: (id) => {
 			restStore.update((state) => {
 				const index = state.requests.findIndex((request) => request.id === id);
@@ -140,7 +124,7 @@ export const setRESTStore = (initialData: Partial<TRESTData> = REST_INITIAL_DATA
 	};
 
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
-	restStore.subscribe(({ editRequest, predictedRequest, ...state }) => {
+	restStore.subscribe(({ editRequest, ...state }) => {
 		if (browser) localStorage.setItem(REST_STORAGE_KEY, JSON.stringify(state));
 	});
 


### PR DESCRIPTION
Fixed bug reported in #1, that a duplicated tab can't open the rename dialog. 