### PR TITLE
fix: rename rest-tab context methods and fix renaming request behavio…

### DIFF
--- a/src/lib/components/ui/codemirror/codemirror.svelte
+++ b/src/lib/components/ui/codemirror/codemirror.svelte
@@ -14,7 +14,7 @@
 
 <CodeMirror
 	class={cn('flex h-full w-full flex-1 flex-col', className)}
-	lang={lang && langs[lang]()}
+	lang={lang ? langs[lang]() : undefined}
 	styles={theme}
 	{...$$restProps}
 	bind:value

--- a/src/lib/contexts/rest-tab.context.ts
+++ b/src/lib/contexts/rest-tab.context.ts
@@ -16,19 +16,25 @@ export type TRESTTabDataPersist = {
 	current?: TRESTTabInfer['context']['id'];
 };
 export type TRESTTabActions = {
-	add: (request?: TRESTTabInfer['context']) => void;
-	get: (id: TRESTTabInfer['context']['id']) => TRESTTabInfer | undefined;
-	update: (id: TRESTTabInfer['context']['id'], request: Partial<TRESTTabInfer['context']>) => void;
-	duplicate: (id: TRESTTabInfer['context']['id']) => void;
-	setCurrent: (id?: TRESTTabInfer['context']['id']) => void;
-	setCurrentTab: (id: TRESTTabInfer['context']['id'], tab: TRESTTabInfer['currentTab']) => void;
-	setTainted: (ids?: Array<TRESTTabInfer['context']['id']>) => void;
-	setDirty: (ids: Array<TRESTTabInfer['context']['id']>, dirty: TRESTTabInfer['dirty']) => void;
+	addTab: (request?: TRESTTabInfer['context']) => void;
+	getTab: (id: TRESTTabInfer['context']['id']) => TRESTTabInfer | undefined;
+	updateTab: (
+		id: TRESTTabInfer['context']['id'],
+		request: Partial<TRESTTabInfer['context']>
+	) => void;
+	duplicateTab: (id: TRESTTabInfer['context']['id']) => void;
+	setCurrentTab: (id?: TRESTTabInfer['context']['id']) => void;
+	setCurrentInnerTab: (
+		id: TRESTTabInfer['context']['id'],
+		tab: TRESTTabInfer['currentTab']
+	) => void;
+	setTaintedTabs: (ids?: Array<TRESTTabInfer['context']['id']>) => void;
+	setDirtyTabs: (ids: Array<TRESTTabInfer['context']['id']>, dirty: TRESTTabInfer['dirty']) => void;
 	setResult: (
 		id: TRESTTabInfer['context']['id'],
 		result?: Partial<Pick<TRESTResult, 'response' | 'sending'>>
 	) => void;
-	close: (props: {
+	closeTabs: (props: {
 		ids: Array<TRESTTabInfer['context']['id']>;
 		mode: 'normal' | 'close-others' | 'close-all';
 	}) => void;
@@ -91,7 +97,7 @@ export function setRESTTabContext(
 	}
 
 	const actions: TRESTTabActions = {
-		add: (request) => {
+		addTab: (request) => {
 			let newTab: TRESTTabInfer;
 
 			if (request) {
@@ -119,11 +125,11 @@ export function setRESTTabContext(
 				return state;
 			});
 		},
-		get: (id) => {
+		getTab: (id) => {
 			const { tabs } = get(store);
 			return tabs.find((tab) => tab.id === id);
 		},
-		update: (id, request) => {
+		updateTab: (id, request) => {
 			const { tabs } = get(store);
 			const index = tabs.findIndex((tab) => tab.id === id);
 			if (index === -1) return;
@@ -134,7 +140,7 @@ export function setRESTTabContext(
 				return state;
 			});
 		},
-		duplicate: (id) => {
+		duplicateTab: (id) => {
 			const { tabs } = get(store);
 			const index = tabs.findIndex((tab) => tab.id === id);
 			if (index === -1) return;
@@ -156,7 +162,7 @@ export function setRESTTabContext(
 				return state;
 			});
 		},
-		setCurrent: (id) => {
+		setCurrentTab: (id) => {
 			const { tabs, current } = get(store);
 			const index = tabs.findIndex((tab) => tab.id === id);
 			if (index === -1 || current === id) return;
@@ -167,7 +173,7 @@ export function setRESTTabContext(
 				return state;
 			});
 		},
-		setDirty: (ids, dirty) => {
+		setDirtyTabs: (ids, dirty) => {
 			const { tabs } = get(store);
 			for (const tab of tabs) if (ids.includes(tab.id)) tab.dirty = dirty;
 
@@ -177,7 +183,7 @@ export function setRESTTabContext(
 				return state;
 			});
 		},
-		setCurrentTab(id, tab) {
+		setCurrentInnerTab(id, tab) {
 			const { tabs } = get(store);
 			const index = tabs.findIndex((tab) => tab.id === id);
 			if (index === -1) return;
@@ -188,7 +194,7 @@ export function setRESTTabContext(
 				return state;
 			});
 		},
-		setTainted: (ids) => {
+		setTaintedTabs: (ids) => {
 			if (!ids) {
 				return store.update((state) => {
 					state.tainted = [];
@@ -230,7 +236,7 @@ export function setRESTTabContext(
 				return state;
 			});
 		},
-		close: ({ ids, mode } = { ids: [], mode: 'normal' }) => {
+		closeTabs: ({ ids, mode } = { ids: [], mode: 'normal' }) => {
 			const { current } = get(store);
 			const hasCurrent = current ? ids.includes(current) : false;
 

--- a/src/lib/layouts/rest/alert-dialogs/alert-dialog-request-deletion/alert-dialog-request-deletion.layout.svelte
+++ b/src/lib/layouts/rest/alert-dialogs/alert-dialog-request-deletion/alert-dialog-request-deletion.layout.svelte
@@ -11,8 +11,8 @@
 		if (!$dialogStore.requestID) return;
 
 		restContext.removeFile($dialogStore.requestID);
-		tabContext.close({ ids: [$dialogStore.requestID], mode: 'normal' });
-		tabContext.setTainted(undefined);
+		tabContext.closeTabs({ ids: [$dialogStore.requestID], mode: 'normal' });
+		tabContext.setTaintedTabs(undefined);
 		dialogStore.set({ open: false, requestID: undefined });
 	}
 </script>

--- a/src/lib/layouts/rest/alert-dialogs/alert-dialog-unsaved-changes/alert-dialog-unsaved-changes.layout.svelte
+++ b/src/lib/layouts/rest/alert-dialogs/alert-dialog-unsaved-changes/alert-dialog-unsaved-changes.layout.svelte
@@ -13,8 +13,8 @@
 	);
 
 	function handleDiscard() {
-		if (dirtyTabs.length === 1) tabContext.close({ ids: $tabContext.tainted, mode: 'normal' });
-		tabContext.setTainted(undefined);
+		if (dirtyTabs.length === 1) tabContext.closeTabs({ ids: $tabContext.tainted, mode: 'normal' });
+		tabContext.setTaintedTabs(undefined);
 	}
 
 	function handleSave() {
@@ -26,20 +26,20 @@
 
 			if (found) {
 				restContext.updateFile(request);
-				tabContext.close({ ids: [request.id], mode: 'normal' });
+				tabContext.closeTabs({ ids: [request.id], mode: 'normal' });
 			} else {
 				dialogStore.set({
 					open: true,
 					request,
-					onSave: () => tabContext.close({ ids: [request.id], mode: 'normal' })
+					onSave: () => tabContext.closeTabs({ ids: [request.id], mode: 'normal' })
 				});
 			}
 		} else if (requests.length > 1) {
 			for (const request of requests) restContext.updateFile(request);
-			tabContext.close({ ids: $tabContext.tainted, mode: 'normal' });
+			tabContext.closeTabs({ ids: $tabContext.tainted, mode: 'normal' });
 		}
 
-		tabContext.setTainted(undefined);
+		tabContext.setTaintedTabs(undefined);
 	}
 </script>
 

--- a/src/lib/layouts/rest/context-menus/context-menu-edit-request/context-menu-edit-request.layout.svelte
+++ b/src/lib/layouts/rest/context-menus/context-menu-edit-request/context-menu-edit-request.layout.svelte
@@ -38,7 +38,7 @@
 			shortcut: 'R',
 			icon: FileEdit,
 			action: () => {
-				const { context: request } = tabContext.get(tabID) as TRESTTabInfer;
+				const { context: request } = tabContext.getTab(tabID) as TRESTTabInfer;
 				dialogStore.set({ mode: 'edit', open: true, request });
 			}
 		},
@@ -46,15 +46,15 @@
 			label: 'Duplicate',
 			shortcut: 'D',
 			icon: Copy,
-			action: () => tabContext.duplicate(tabID)
+			action: () => tabContext.duplicateTab(tabID)
 		},
 		{
 			label: 'Close',
 			shortcut: 'W',
 			icon: XCircle,
 			action: () => {
-				if (tabContext.get(tabID)?.dirty) tabContext.setTainted([tabID]);
-				else tabContext.close({ ids: [tabID], mode: 'normal' });
+				if (tabContext.getTab(tabID)?.dirty) tabContext.setTaintedTabs([tabID]);
+				else tabContext.closeTabs({ ids: [tabID], mode: 'normal' });
 			}
 		},
 		{
@@ -64,8 +64,8 @@
 			action: () => {
 				const otherTabs = $tabContext.tabs.filter((tab) => tab.id !== tabID);
 				const dirtyTabs = otherTabs.filter((tab) => tab.dirty);
-				if (dirtyTabs.length) tabContext.setTainted(otherTabs.map((tab) => tab.id));
-				else tabContext.close({ ids: [tabID], mode: 'close-others' });
+				if (dirtyTabs.length) tabContext.setTaintedTabs(otherTabs.map((tab) => tab.id));
+				else tabContext.closeTabs({ ids: [tabID], mode: 'close-others' });
 			},
 			showOnlyIf: () => !hasOnlyOneTab
 		},
@@ -75,8 +75,8 @@
 			icon: XOctagon,
 			action: () => {
 				const dirtyTabs = $tabContext.tabs.filter((tab) => tab.dirty);
-				if (dirtyTabs.length) tabContext.setTainted($tabContext.tabs.map((tab) => tab.id));
-				else tabContext.close({ ids: [], mode: 'close-all' });
+				if (dirtyTabs.length) tabContext.setTaintedTabs($tabContext.tabs.map((tab) => tab.id));
+				else tabContext.closeTabs({ ids: [], mode: 'close-all' });
 			},
 			showOnlyIf: () => !hasOnlyOneTab
 		}

--- a/src/lib/layouts/rest/dialogs/dialog-edit-request/dialog-edit-request.layout.svelte
+++ b/src/lib/layouts/rest/dialogs/dialog-edit-request/dialog-edit-request.layout.svelte
@@ -59,11 +59,11 @@
 					restContext.updateFile(request);
 				}
 
-				const tab = tabContext.get(requestID);
+				const tab = tabContext.getTab(requestID);
 				if (!tab) return;
 
-				tabContext.update(requestID, $formData as TRESTRequestInfer);
-				if (!$dialogStore.forceSave) tabContext.setDirty([requestID], true);
+				tabContext.updateTab(requestID, $formData as TRESTRequestInfer);
+				if (!$dialogStore.forceSave) tabContext.setDirtyTabs([requestID], true);
 			}
 		} as const satisfies Record<typeof $dialogStore.mode, () => void>;
 

--- a/src/lib/layouts/rest/dialogs/dialog-save-as/dialog-save-as.layout.svelte
+++ b/src/lib/layouts/rest/dialogs/dialog-save-as/dialog-save-as.layout.svelte
@@ -9,7 +9,7 @@
 	import * as Breadcrumb from '$lib/components/ui/breadcrumb';
 	import * as Dialog from '$lib/components/ui/dialog';
 	import * as Form from '$lib/components/ui/form';
-	import { defaults, superForm } from 'sveltekit-superforms';
+	import { defaults, superForm, type ChangeEvent } from 'sveltekit-superforms';
 	import { zod } from 'sveltekit-superforms/adapters';
 
 	type TFormAction = 'save' | 'cancel';
@@ -28,6 +28,7 @@
 		validators: zod(RESTRequestSchema),
 		validationMethod: 'oninput',
 		resetForm: true,
+		onChange: handleOnChange,
 		onSubmit: (input) => {
 			input.cancel();
 			return handleFormSubmit();
@@ -67,10 +68,15 @@
 		} as const satisfies Record<NonNullable<typeof selectedType>, () => void>;
 
 		ACTIONS[selectedType]();
-		tabContext.update(data.id, data);
-		tabContext.setDirty([data.id], false);
+		tabContext.setDirtyTabs([data.id], false);
 		$dialogStore.onSave?.();
-		dialogStore.set({ open: false, request: undefined });
+		dialogStore.set({ open: false, request: undefined, onSave: undefined });
+	}
+
+	function handleOnChange(event: ChangeEvent<TRESTRequestInfer>) {
+		if (!event.target) return;
+		tabContext.setDirtyTabs([$formData.id], true);
+		tabContext.updateTab($formData.id, { name: $formData.name });
 	}
 
 	function handleOpenChange(event: boolean) {

--- a/src/lib/layouts/rest/popovers/popover-save-options/popover-save-options.layout.svelte
+++ b/src/lib/layouts/rest/popovers/popover-save-options/popover-save-options.layout.svelte
@@ -42,7 +42,7 @@
 	$: ({ form: formData } = form);
 
 	$: if ($tabContext.tabs) {
-		tab = tabContext.get(tabID) as TRESTTabInfer;
+		tab = tabContext.getTab(tabID) as TRESTTabInfer;
 		if (tab) $formData = tab.context;
 	}
 
@@ -53,8 +53,8 @@
 
 	function handleOnChange(event: ChangeEvent<TSaveOptionsInfer>) {
 		if (!event.target) return;
-		tabContext.setDirty([tabID], true);
-		tabContext.update(tabID, { name: $formData.name });
+		tabContext.setDirtyTabs([tabID], true);
+		tabContext.updateTab(tabID, { name: $formData.name });
 	}
 </script>
 

--- a/src/lib/layouts/rest/tabs/tab-body/tab-body.layout.svelte
+++ b/src/lib/layouts/rest/tabs/tab-body/tab-body.layout.svelte
@@ -3,11 +3,12 @@
 	import { ToolbarBody } from '$lib/layouts/rest/toolbars/toolbar-body';
 	import { FeedbackBodyEmpty } from '$lib/layouts/rest/feedbacks/feedback-body-empty';
 	import { BodyContentTypeEnum, type TRESTRequestInfer, type TRESTTabInfer } from '$lib/validators';
-	import type { Langs } from '$lib/components/ui/codemirror';
+	import type { Langs, Props as TCodeMirror } from '$lib/components/ui/codemirror';
 	import type { SuperForm } from 'sveltekit-superforms';
 
-	const { options: contentTypeOptions } = BodyContentTypeEnum;
+	const CODEMIRROR_CONFIG: TCodeMirror = { editable: true, useTab: true, tabSize: 2 } as const;
 
+	const { options: contentTypeOptions } = BodyContentTypeEnum;
 	type TContentTypeOption = (typeof contentTypeOptions)[number];
 
 	const CONTENT_TYPES_LANGS = {
@@ -41,7 +42,7 @@
 
 {#if tab?.context.body.contentType !== null}
 	{#await Promise.all(LAZY_COMPONENTS) then [{ CodeMirror }]}
-		<CodeMirror editable {lang} bind:value={$formData.body.body} />
+		<CodeMirror {...CODEMIRROR_CONFIG} {lang} bind:value={$formData.body.body} />
 	{/await}
 {:else}
 	<FeedbackBodyEmpty />

--- a/src/lib/layouts/rest/tabs/tab-body/tab-body.layout.svelte
+++ b/src/lib/layouts/rest/tabs/tab-body/tab-body.layout.svelte
@@ -32,7 +32,7 @@
 
 	$: ({ form: formData } = form);
 	$: if ($tabContext.tabs) {
-		tab = tabContext.get(tabID) as TRESTTabInfer;
+		tab = tabContext.getTab(tabID) as TRESTTabInfer;
 	}
 	$: if (tab) lang = CONTENT_TYPES_LANGS[tab.context.body.contentType || 'text/plain'];
 </script>

--- a/src/lib/layouts/rest/tabs/tab-headers/tab-headers.layout.svelte
+++ b/src/lib/layouts/rest/tabs/tab-headers/tab-headers.layout.svelte
@@ -32,11 +32,11 @@
 	}
 
 	function handleRedirect() {
-		tabContext.setCurrentTab(tabID, 'body');
+		tabContext.setCurrentInnerTab(tabID, 'body');
 	}
 
 	onMount(() => {
-		if (!hasHeaders) tabContext.update(tabID, { headers: [DEFAULT_HEADER] });
+		if (!hasHeaders) tabContext.updateTab(tabID, { headers: [DEFAULT_HEADER] });
 	});
 </script>
 

--- a/src/lib/layouts/rest/tabs/tab-params/tab-params.layout.svelte
+++ b/src/lib/layouts/rest/tabs/tab-params/tab-params.layout.svelte
@@ -32,7 +32,7 @@
 	}
 
 	onMount(() => {
-		if (!hasParams) tabContext.update(tabID, { params: [DEFAULT_KEY_VALUE] });
+		if (!hasParams) tabContext.updateTab(tabID, { params: [DEFAULT_KEY_VALUE] });
 	});
 </script>
 

--- a/src/lib/layouts/rest/tabs/tab-request/tab-request.layout.svelte
+++ b/src/lib/layouts/rest/tabs/tab-request/tab-request.layout.svelte
@@ -86,7 +86,7 @@
 
 	$: sending = $tabContext.results.find((result) => result.id === tabID)?.sending;
 	$: if ($tabContext.tabs) {
-		tab = tabContext.get(tabID) as TRESTTabInfer;
+		tab = tabContext.getTab(tabID) as TRESTTabInfer;
 		if (tab) {
 			currentTab = tab.currentTab;
 			form.reset({ id: formID, data: tab.context });
@@ -101,7 +101,7 @@
 
 	function handleCurrentTab(value: TAvailableTabs) {
 		currentTab = value;
-		tabContext.setCurrentTab(tabID, value);
+		tabContext.setCurrentInnerTab(tabID, value);
 	}
 
 	function handleOnChange(event: ChangeEvent<TRESTRequestInfer>) {
@@ -118,10 +118,10 @@
 				request = { [path as keyof TRESTRequestInfer]: $formData[path as keyof TRESTRequestInfer] };
 			}
 
-			tabContext.update(tabID, request);
+			tabContext.updateTab(tabID, request);
 		}
 
-		tabContext.setDirty([tabID], true);
+		tabContext.setDirtyTabs([tabID], true);
 	}
 
 	function handleKeydown(event: KeyboardEvent) {
@@ -211,8 +211,8 @@
 		const data = $formData as TRESTRequestInfer;
 
 		const updateTab = () => {
-			tabContext.update(tabID, $formData);
-			tabContext.setDirty([tabID], false);
+			tabContext.updateTab(tabID, $formData);
+			tabContext.setDirtyTabs([tabID], false);
 		};
 
 		if (found) {
@@ -373,7 +373,7 @@
 							class="relative gap-2 px-0 py-2 text-muted-foreground !shadow-none before:absolute before:inset-x-0 before:bottom-0 before:h-[.125rem] before:bg-transparent before:transition-colors data-[state=active]:text-accent-foreground data-[state=active]:before:bg-primary hover:text-accent-foreground"
 							on:click={() => handleCurrentTab(value)}
 						>
-							<span class="capitalize">{label}</span>
+							<span class="select-none capitalize">{label}</span>
 							{#if dynamicCounters[value]}
 								<Badge size="sm" variant="outline" class="!text-foreground">
 									{dynamicCounters[value]}

--- a/src/lib/layouts/rest/toolbars/toolbar-body/toolbar-body.layout.svelte
+++ b/src/lib/layouts/rest/toolbars/toolbar-body/toolbar-body.layout.svelte
@@ -38,12 +38,12 @@
 
 		if (contentTypeHeaderIndex !== -1 && $formData.headers[contentTypeHeaderIndex].override) {
 			$formData.headers[contentTypeHeaderIndex].value = event.value || '';
-			tabContext.update(tabID, {
+			tabContext.updateTab(tabID, {
 				headers: $formData.headers,
 				body: { ...$formData.body, contentType: event.value }
 			});
 		} else {
-			tabContext.update(tabID, { body: { ...$formData.body, contentType: event.value } });
+			tabContext.updateTab(tabID, { body: { ...$formData.body, contentType: event.value } });
 		}
 	}
 
@@ -60,16 +60,16 @@
 		);
 
 		if (headerIndex === -1) {
-			tabContext.update(tabID, { headers: [...$formData.headers, updatedHeader] });
+			tabContext.updateTab(tabID, { headers: [...$formData.headers, updatedHeader] });
 		} else {
-			tabContext.update(tabID, {
+			tabContext.updateTab(tabID, {
 				headers: $formData.headers.map((header, index) =>
 					index === headerIndex ? updatedHeader : header
 				)
 			});
 		}
 
-		tabContext.setCurrentTab(tabID, 'headers');
+		tabContext.setCurrentInnerTab(tabID, 'headers');
 	}
 
 	onMount(() => {

--- a/src/lib/layouts/rest/toolbars/toolbar-headers/toolbar-headers.layout.svelte
+++ b/src/lib/layouts/rest/toolbars/toolbar-headers/toolbar-headers.layout.svelte
@@ -27,7 +27,7 @@
 	}
 
 	function handleAddNew() {
-		tabContext.update(tabID, { headers: [...$formData.headers, DEFAULT_HEADER] });
+		tabContext.updateTab(tabID, { headers: [...$formData.headers, DEFAULT_HEADER] });
 	}
 
 	onMount(() => {

--- a/src/lib/layouts/rest/toolbars/toolbar-params/toolbar-params.layout.svelte
+++ b/src/lib/layouts/rest/toolbars/toolbar-params/toolbar-params.layout.svelte
@@ -27,7 +27,7 @@
 	}
 
 	function handleAddNew() {
-		tabContext.update(tabID, { params: [...$formData.params, DEFAULT_KEY_VALUE] });
+		tabContext.updateTab(tabID, { params: [...$formData.params, DEFAULT_KEY_VALUE] });
 	}
 
 	onMount(() => {

--- a/src/lib/layouts/rest/trees/tree-collection/tree-file/tree-file.layout.svelte
+++ b/src/lib/layouts/rest/trees/tree-collection/tree-file/tree-file.layout.svelte
@@ -23,7 +23,7 @@
 	function handleOpenFile(event: MouseEvent) {
 		event.stopPropagation();
 		$treeStore.selected = file.id;
-		tabContext.get(file.id) ? tabContext.setCurrent(file.id) : tabContext.add(file);
+		tabContext.getTab(file.id) ? tabContext.setCurrentTab(file.id) : tabContext.addTab(file);
 	}
 </script>
 

--- a/src/lib/layouts/rest/views/view-editor/view-editor.layout.svelte
+++ b/src/lib/layouts/rest/views/view-editor/view-editor.layout.svelte
@@ -31,7 +31,7 @@
 	function handleCurrentTab(event: MouseEvent, tabID: TRESTTabInfer['id']) {
 		event.stopPropagation();
 
-		tabContext.setCurrent(tabID);
+		tabContext.setCurrentTab(tabID);
 		scrollToActiveTab();
 	}
 
@@ -43,13 +43,15 @@
 		const isKeyboardEvent = event instanceof KeyboardEvent && event.key === 'Enter';
 
 		if (isMouseEvent || isKeyboardEvent) {
-			const isDirty = tabContext.get(tabID)?.dirty;
-			isDirty ? tabContext.setTainted([tabID]) : tabContext.close({ ids: [tabID], mode: 'normal' });
+			const isDirty = tabContext.getTab(tabID)?.dirty;
+			isDirty
+				? tabContext.setTaintedTabs([tabID])
+				: tabContext.closeTabs({ ids: [tabID], mode: 'normal' });
 		}
 	}
 
 	function handleEditing(tabID: TRESTTabInfer['id']) {
-		const { context: request } = tabContext.get(tabID) as TRESTTabInfer;
+		const { context: request } = tabContext.getTab(tabID) as TRESTTabInfer;
 		dialogStore.set({ mode: 'edit', open: true, request });
 	}
 
@@ -168,7 +170,7 @@
 					tabindex={0}
 					aria-label="New Tab"
 					class="mx-3 h-8 w-8 shrink-0"
-					on:click={() => tabContext.add()}
+					on:click={() => tabContext.addTab()}
 				>
 					<Plus class="h-4 w-4 shrink-0" />
 					<span class="sr-only select-none">New Tab</span>

--- a/src/lib/layouts/rest/views/view-response/view-response.layout.svelte
+++ b/src/lib/layouts/rest/views/view-response/view-response.layout.svelte
@@ -5,9 +5,9 @@
 	import type { Props as TCodeMirror } from '$lib/components/ui/codemirror';
 
 	const CODEMIRROR_CONFIG: TCodeMirror = {
-		editable: true,
+		editable: false,
 		readonly: true,
-		useTab: false,
+		useTab: true,
 		tabSize: 2,
 		nodebounce: true
 	} as const;

--- a/src/lib/layouts/rest/views/view-rest/view-rest.layout.svelte
+++ b/src/lib/layouts/rest/views/view-rest/view-rest.layout.svelte
@@ -38,7 +38,7 @@
 	function handleKeydown(event: KeyboardEvent) {
 		if (event.ctrlKey && event.altKey && event.key === 'n') {
 			event.preventDefault();
-			tabContext.add();
+			tabContext.addTab();
 		}
 	}
 </script>
@@ -92,7 +92,7 @@
 					builders={[builder]}
 					variant="outline"
 					aria-label="Open REST Navigation"
-					class="mx-auto border-b-0"
+					class="border-x-0 border-b-0"
 				>
 					<ChevronUp class="h-5 w-5" />
 					<span class="sr-only select-none">Open Navigation</span>

--- a/src/lib/layouts/rest/views/view-welcome/view-welcome.layout.svelte
+++ b/src/lib/layouts/rest/views/view-welcome/view-welcome.layout.svelte
@@ -18,7 +18,7 @@
 	role="presentation"
 	tabindex="-1"
 	class="flex h-full cursor-default select-none flex-col focus-visible:focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-	on:dblclick={() => tabContext.add()}
+	on:dblclick={() => tabContext.addTab()}
 >
 	<Center>
 		<figure aria-hidden="true" class="mb-2 aspect-square opacity-10 grayscale">

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,16 @@
 import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vite';
 
+const isDev = process.env.NODE_ENV === 'development';
+
 export default defineConfig({
 	plugins: [sveltekit()],
 	optimizeDeps: {
-		exclude: ['codemirror', '@codemirror/lang-html', '@codemirror/lang-json']
+		exclude: [
+			...(isDev ? ['svelte-codemirror-editor'] : []),
+			'codemirror',
+			'@codemirror/lang-html',
+			'@codemirror/lang-json'
+		]
 	}
 });


### PR DESCRIPTION
- [x] Rename `rest-tab` context methods to not override native methods of svelte stores
- [x] Fix renaming request behavior in `dialog-save-as`